### PR TITLE
Fix Versioneer compatibility with Python 3.12

### DIFF
--- a/versioneer.py
+++ b/versioneer.py
@@ -341,7 +341,10 @@ def get_config_from_root(root):
     setup_cfg = os.path.join(root, "setup.cfg")
     parser = configparser.ConfigParser()
     with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+        if hasattr(parser, "read_file"):
+            parser.read_file(f)
+        else:
+            parser.readfp(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):


### PR DESCRIPTION
## Summary
- prevent build errors when using ConfigParser in Python 3.12

## Testing
- `python -m pip install .`


------
https://chatgpt.com/codex/tasks/task_e_687fa6feefe88333a5a2cf9dd83c5392